### PR TITLE
Add support for seek from end

### DIFF
--- a/src/dev/channel.h
+++ b/src/dev/channel.h
@@ -38,6 +38,7 @@
 
 #define CDEV_SEEK_ABSOLUTE  0
 #define CDEV_SEEK_RELATIVE  1
+#define CDEV_SEEK_END       2
 
 /*
  * Structure defining a channel

--- a/src/dev/fsys.c
+++ b/src/dev/fsys.c
@@ -566,7 +566,7 @@ short fchan_seek(t_channel * chan, long position, short base) {
             return ERR_GENERAL; 
         }
 
-        return fatfs_to_foenix(f_lseek(file, position));
+        return fatfs_to_foenix(f_lseek(file, new_position));
     }
 
     return ERR_BADCHANNEL;

--- a/vbcc/config/m68k-foenix
+++ b/vbcc/config/m68k-foenix
@@ -1,5 +1,5 @@
--cc=vbccm68k -quiet %s -o= %s %s -O=%ld -ID:\projects\FoenixMCP\vbcc\targets\m68k-foenix\include
--ccv=vbccm68k %s -o= %s %s -O=%ld -ID:\projects\FoenixMCP\vbcc\targets\m68k-foenix\include
+-cc=vbccm68k -quiet %s -o= %s %s -O=%ld -IC:\A2560U\FoenixMCP\vbcc\targets\m68k-foenix\include
+-ccv=vbccm68k %s -o= %s %s -O=%ld -IC:\A2560U\FoenixMCP\vbcc\targets\m68k-foenix\include
 -as=vasmm68k_mot -quiet -Fvobj -nowarn=62 %s -o %s
 -asv=vasmm68k_mot -Fvobj -nowarn=62 %s -o %s
 -rm=del %s


### PR DESCRIPTION
Common OSes (DOS, Linux, TOS) provide a third mode for the "seek" function to position the "pointer" from the end of the file. This can be used when no other function exists for determining a file's size.